### PR TITLE
Reduce measure errors

### DIFF
--- a/src/HCSR04.cpp
+++ b/src/HCSR04.cpp
@@ -24,6 +24,9 @@ float HCSR04::dist(int n) const
 	digitalWrite(this->out, HIGH);
 	delayMicroseconds(10);
 	digitalWrite(this->out, LOW);
-	return pulseIn(this->echo[n], HIGH) / 58.0;
+	noInterrupts();
+	float d=pulseIn(this->echo[n], HIGH);
+	interrupts();
+	return d / 58.0;
 }
 float HCSR04::dist() const{return this->dist(0);}

--- a/src/HCSR04.h
+++ b/src/HCSR04.h
@@ -6,7 +6,7 @@ class HCSR04
 	HCSR04(int out,int echo[],int n);		//initialisation class HCSR04 (trig pin , echo pin)
 	~HCSR04();								//destructor
 	float dist()      const;				//return curent distance of element 0
-	float dist(int n)      const;				//return curent distance of element 0
+	float dist(int n)      const;				//return curent distance of element n
 
 	private:
 	void init(int out,int echo[],int n); 			//for constructor


### PR DESCRIPTION
According to docs, pulseIn works better in noInterrupts() mode, so I added a critical section.
The float division is kept outside on purpose (it's slow and can run with interrupts enabled).

Moreover, there was an obvious copy-paste error in header file.

Hope it helps.